### PR TITLE
Added Django 1.10 support

### DIFF
--- a/fixture_media/management/commands/collectmedia.py
+++ b/fixture_media/management/commands/collectmedia.py
@@ -14,12 +14,15 @@ class Command(BaseCommand):
     """Management command to collect media files."""
 
     can_import_settings = True
-    opt = make_option('--noinput',
-                      action='store_false',
-                      dest='interactive',
-                      default=True,
-                      help='Do NOT prompt the user for input of any kind.')
-    option_list = BaseCommand.option_list + (opt, )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--noinput',
+            action='store_false',
+            dest='interactive',
+            default=True,
+            help='Do NOT prompt the user for input of any kind.'
+        )
 
     def handle(self, **options):
         """Handle command invocation."""


### PR DESCRIPTION
"option_list" is not supported anymore in Django 1.10. Using "parser.add_argument()" instead.